### PR TITLE
numexpr 2.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,9 @@ source:
   sha256: cd779aa44dd986c4ef10163519239602b027be06a527946656207acf1f58113b
 
 build:
-  number: 1
+  number: 0
   skip: True  # [blas_impl == 'openblas' and win]
+  skip: True  # [py<36]
   script:
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -24,14 +25,18 @@ requirements:
     - numpy
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
-    - setuptools
+    - packaging
     - {{ pin_compatible('numpy') }}
 test:
   requires:
-    - setuptools
     - nomkl  # [x86 and blas_impl == 'openblas']
+    - pip
+  commands:
+    - pip check
   imports:
     - numexpr
     - numexpr.interpreter
@@ -39,6 +44,7 @@ test:
 about:
   home: https://github.com/pydata/numexpr
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
   summary: 'Fast numerical expression evaluator for NumPy.'
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.7.3" %}
+{% set version = "2.8.1" %}
 
 package:
   name: numexpr
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/numexpr/numexpr-{{ version }}.tar.gz
-  sha256: 43616529f9b7d1afc83386f943dc66c4da5e052f00217ba7e3ad8dd1b5f3a825
+  sha256: cd779aa44dd986c4ef10163519239602b027be06a527946656207acf1f58113b
 
 build:
   number: 1


### PR DESCRIPTION
Update numexpr to 2.8.1

Bug Tracker: new open issues https://github.com/pydata/numexpr/issues
Github releases:  https://github.com/pydata/numexpr/releases
Upstream setup.cfg:  https://github.com/pydata/numexpr/blob/v2.8.1/setup.cfg
Upstream setup.py:  https://github.com/pydata/numexpr/blob/v2.8.1/setup.py
Upstream requirements: https://github.com/pydata/numexpr/blob/v2.8.1/requirements.txt
Upstream pyproject.toml:  https://github.com/pydata/numexpr/blob/v2.8.1/pyproject.toml

The package numexpr is mentioned inside the packages:
bcolz | pandas | pytables |

Actions:
1. Reset build number to `0`
2. Skip `py<36`
3. Add missing packages in host: `setuptools`, `wheel`
4. Remove `setuptools` from run, see https://github.com/pydata/numexpr/commit/aa9fc29019cf899533cf65020d4020606fd1d301#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552
5. Add `packaging` in run
6. Add `pip check`
7. Add license_family

Result:
- all-succeeded
