### PR TITLE
numexpr 2.8.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.8.1" %}
+{% set version = "2.8.3" %}
 
 package:
   name: numexpr
@@ -6,14 +6,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/numexpr/numexpr-{{ version }}.tar.gz
-  sha256: cd779aa44dd986c4ef10163519239602b027be06a527946656207acf1f58113b
+  sha256: 9fec076b76c90a5f3929373f548834bb203c6d23a81a895e60d0fe9cca075e99
 
 build:
-  number: 2
+  number: 0
   skip: True  # [blas_impl == 'openblas' and win]
-  skip: True  # [py<36]
-  script:
-    - "{{ PYTHON }} -m pip install . --no-deps -vv"
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/numexpr/numexpr-{{ version }}.tar.gz
-  sha256: 9fec076b76c90a5f3929373f548834bb203c6d23a81a895e60d0fe9cca075e99
+  sha256: cb647c9d9c785dae0759bf6c875cde2bec472b5c3f7a6015734b161ae766d141
 
 build:
   number: 0


### PR DESCRIPTION
Update numexpr to 2.8.3

Bug Tracker: new open issues https://github.com/pydata/numexpr/issues
Github releases: https://github.com/pydata/numexpr/releases
Upstream setup.cfg: https://github.com/pydata/numexpr/blob/v2.8.3/setup.cfg
Upstream setup.py: https://github.com/pydata/numexpr/blob/v2.8.3/setup.py
Upstream requirements: https://github.com/pydata/numexpr/blob/v2.8.3/requirements.txt
Upstream pyproject.toml: https://github.com/pydata/numexpr/blob/v2.8.3/pyproject.toml

The package numexpr is mentioned inside the packages:
bcolz | pandas | pytables |
Actions:
1. Skip py<37
2. Reset build number to 0 