### PR TITLE
[PKG-3008] numexpr 2.8.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [blas_impl == 'openblas' and win]
-  skip: True  # [py<37]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,16 @@
-{% set version = "2.8.4" %}
+{% set name = "numexpr" %}
+{% set version = "2.8.7" %}
 
 package:
-  name: numexpr
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/n/numexpr/numexpr-{{ version }}.tar.gz
-  sha256: d5432537418d18691b9115d615d6daa17ee8275baef3edf1afbbf8bc69806147 
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 596eeb3bbfebc912f4b6eaaf842b61ba722cebdb8bc42dfefa657d3a74953849
 
 build:
-  number: 1
+  number: 0
   skip: True  # [blas_impl == 'openblas' and win]
   skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
@@ -29,22 +30,22 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
+
 test:
+  # imports are included to run_test.py
   requires:
     - nomkl  # [x86 and blas_impl == 'openblas']
     - pip
+    - pytest
   commands:
     - pip check
-  imports:
-    - numexpr
-    - numexpr.interpreter
 
 about:
   home: https://github.com/pydata/numexpr
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
-  summary: 'Fast numerical expression evaluator for NumPy.'
+  summary: Fast numerical expression evaluator for NumPy
   description: |
     Numexpr is a fast numerical expression evaluator for NumPy. With it,
     expressions that operate on arrays (like "3*a+4*b") are accelerated and use


### PR DESCRIPTION
**Current package info**


| Channel | Downloads | Version | Platforms | License |
| --- | --- | --- | --- | --- |
| defaults | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/numexpr.svg)](https://anaconda.org/main/numexpr) | [![Conda Version](https://img.shields.io/conda/vn/main/numexpr.svg)](https://anaconda.org/main/numexpr) | [![Conda Platforms](https://img.shields.io/conda/pn/main/numexpr.svg)](https://anaconda.org/main/numexpr) | ![Conda License](https://img.shields.io/conda/l/main/numexpr) |

Changelog:
License: https://github.com/pydata/numexpr/blob/v2.8.7/LICENSE.txt
Requirements:
- https://github.com/pydata/numexpr/blob/v2.8.7/pyproject.toml
- https://github.com/pydata/numexpr/blob/v2.8.7/requirements.txt
- https://github.com/pydata/numexpr/blob/v2.8.7/setup.cfg
- https://github.com/pydata/numexpr/blob/v2.8.7/setup.py

Actions:
1. Reset the build number to `0`
2. Remove `test/imports` as they are included in `run_test.py` (to satisfy `anaconda-linter`)

Notes:
- this version enables python 3.12 support, see https://github.com/pydata/numexpr/blob/v2.8.7/RELEASE_NOTES.rst#changes-from-286-to-287