### PR TITLE
Update 2.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,14 +22,14 @@ requirements:
   host:
     - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl' and x86]
     - openblas-devel {{ openblas }}  # [blas_impl == 'openblas' and x86]
-    - numpy {{ numpy }}
+    - numpy >=2.0.0
     - python
     - pip
     - setuptools
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy>=1.23.0
 
 test:
   # imports are included to run_test.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "numexpr" %}
-{% set version = "2.8.7" %}
+{% set version = "2.10.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 596eeb3bbfebc912f4b6eaaf842b61ba722cebdb8bc42dfefa657d3a74953849
+  sha256: 9bba99d354a65f1a008ab8b87f07d84404c668e66bab624df5b6b5373403cf81
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy>=1.23.0
+    - numpy >=1.23.0
 
 test:
   # imports are included to run_test.py


### PR DESCRIPTION
numexpr 2.10.1

**Destination channel:** defaults

### Links

- [PKG-4838)](https://anaconda.atlassian.net/browse/PKG-4838) 
- [Upstream repository](https://github.com/pydata/numexpr)
- [Upstream changelog/diff](https://github.com/pydata/numexpr/compare/v2.8.7...v2.10.1)
- Relevant dependency PRs:
  - ...

### Explanation of changes:
- Version bump