### PR TITLE
numexpr 2.14.1 + py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
-# Required for glibc >= 2.26 for intel-openmp to work.
-pkg_build_image_tag: main-rockylinux-8
 build_env_vars:
-  ANACONDA_ROCKET_GLIBC: "2.28"
   ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,4 @@
 pkg_build_image_tag: main-rockylinux-8
 build_env_vars:
   ANACONDA_ROCKET_GLIBC: "2.28"
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ about:
     Numexpr is a fast numerical expression evaluator for NumPy. With it,
     expressions that operate on arrays (like "3*a+4*b") are accelerated and use
     less memory than doing the same calculation in Python.
-  doc_url: https://github.com/pydata/numexpr/wiki/Numexpr-Users-Guide
+  doc_url: https://numexpr.readthedocs.io
   dev_url: https://github.com/pydata/numexpr
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "numexpr" %}
-{% set version = "2.11.0" %}
+{% set version = "2.14.1" %}
 
 package:
   name: {{ name }}
@@ -7,14 +7,13 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 75b2c01a4eda2e7c357bc67a3f5c3dd76506c15b5fd4dc42845ef2e182181bad
+  sha256: 4be00b1086c7b7a5c32e31558122b7b80243fe098579b170967da83f3152b48b
 
 build:
-  number: 1
+  number: 0
   skip: true  # [blas_impl == 'openblas' and win]
   skip: true  # [py<310]
   script:
-    - sed -i.bak 's/^license = "MIT"/license = { text = "MIT" }/' pyproject.toml
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -23,13 +22,12 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl' and x86]
+    - mkl-devel {{ mkl }}  # [blas_impl == 'mkl' and x86]
     - openblas-devel {{ openblas }}  # [blas_impl == 'openblas' and x86]
     - numpy {{ numpy }}
     - python
     - pip
-    - setuptools
-    - wheel
+    - setuptools >=77.0.0
   run:
     - python
     - numpy >=1.23.0
@@ -39,7 +37,7 @@ test:
   requires:
     - nomkl  # [x86 and blas_impl == 'openblas']
     - pip
-    - pytest
+    - pytest >=7.0.0
   commands:
     - pip check
 


### PR DESCRIPTION
numexpr 2.14.1 

**Destination channel:** Defaults

### Links

- [PKG-10476]
- dev_url:        https://github.com/pydata/numexpr/tree/v2.14.1
- conda_forge:    https://github.com/conda-forge/numexpr-feedstock
- pypi:           https://pypi.org/project/numexpr/2.14.1
- pypi inspector: https://inspector.pypi.io/project/numexpr/2.14.1

### Explanation of changes:

- new version number
- add python 3.14 build


[PKG-10476]: https://anaconda.atlassian.net/browse/PKG-10476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ