### PR TITLE
Enable openblas on windows.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+channels:
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr135/e496a4f
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr136/9aa4527
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr134/d228a66
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/da81b3f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr135/e496a4f
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr136/9aa4527
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr134/d228a66
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/da81b3f

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,6 @@
 mkl:
   - 2025.*
+
+blas_impl:
+  - mkl                        # [(x86 or x86_64) and not osx]
+  - openblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: 4be00b1086c7b7a5c32e31558122b7b80243fe098579b170967da83f3152b48b
 
 build:
-  number: 0
-  skip: true  # [blas_impl == 'openblas' and win]
+  number: 1
   skip: true  # [py<310]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv


### PR DESCRIPTION
numexpr: rebuild with openblas/flang for win-64

**Destination channel:** defaults

### Links

- [PKG-13574](https://anaconda.atlassian.net/browse/PKG-13574)

### Explanation of changes:

- add openblas to build matrix for windows and override fortran compiler to flang. Can be removed once https://github.com/AnacondaRecipes/aggregate/pull/438 is available.
- Bump build number



[PKG-13574]: https://anaconda.atlassian.net/browse/PKG-13574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ